### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/demo/src/main/java/net/vrallev/android/task/demo/DoubleFragmentActivity.java
+++ b/demo/src/main/java/net/vrallev/android/task/demo/DoubleFragmentActivity.java
@@ -93,6 +93,8 @@ public class DoubleFragmentActivity extends AppCompatActivity {
 
         private static final String KEY_CUSTOM_ID = "KEY_CUSTOM_ID";
 
+        private String mCustomId;
+        
         public static DoubleFragment create(String customId) {
             Bundle args = new Bundle();
             args.putString(KEY_CUSTOM_ID, customId);
@@ -101,8 +103,6 @@ public class DoubleFragmentActivity extends AppCompatActivity {
             fragment.setArguments(args);
             return fragment;
         }
-
-        private String mCustomId;
 
         @Override
         public void onCreate(@Nullable Bundle savedInstanceState) {

--- a/demo/src/main/java/net/vrallev/android/task/demo/ViewPagerActivity.java
+++ b/demo/src/main/java/net/vrallev/android/task/demo/ViewPagerActivity.java
@@ -53,7 +53,8 @@ public class ViewPagerActivity extends FragmentActivity {
     public static class MyFragment extends Fragment {
 
         private static final String KEY_POSITION = "KEY_POSITION";
-
+        private int mPosition;
+        
         public static MyFragment create(int position) {
             Bundle args = new Bundle();
             args.putInt(KEY_POSITION, position);
@@ -61,8 +62,6 @@ public class ViewPagerActivity extends FragmentActivity {
             fragment.setArguments(args);
             return fragment;
         }
-
-        private int mPosition;
 
         @Nullable
         @Override

--- a/library/src/main/java/net/vrallev/android/task/Task.java
+++ b/library/src/main/java/net/vrallev/android/task/Task.java
@@ -19,8 +19,6 @@ import java.util.concurrent.CountDownLatch;
 @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
 public abstract class Task<RESULT> {
 
-    protected abstract RESULT execute();
-
     private final Object mMonitor;
     private final CountDownLatch mCountDownLatch;
 
@@ -40,6 +38,8 @@ public abstract class Task<RESULT> {
         mCountDownLatch = new CountDownLatch(1);
         mMonitor = new Object();
     }
+    
+    protected abstract RESULT execute();
 
     /*package*/ final void setKey(int key) {
         synchronized (mMonitor) {

--- a/library/src/main/java/net/vrallev/android/task/TaskExecutor.java
+++ b/library/src/main/java/net/vrallev/android/task/TaskExecutor.java
@@ -31,6 +31,14 @@ public final class TaskExecutor {
     private static final AtomicInteger TASK_COUNTER = new AtomicInteger(0);
 
     private static TaskExecutor instance;
+    
+    private ExecutorService mExecutorService;
+    private final PostResult mPostResult;
+
+    private SparseArray<Task<?>> mTasks;
+    private TargetMethodFinder mTargetMethodFinder;
+
+    private Application mApplication;
 
     public static TaskExecutor getInstance() {
         if (instance == null) {
@@ -45,14 +53,6 @@ public final class TaskExecutor {
 
         return instance;
     }
-
-    private ExecutorService mExecutorService;
-    private final PostResult mPostResult;
-
-    private SparseArray<Task<?>> mTasks;
-    private TargetMethodFinder mTargetMethodFinder;
-
-    private Application mApplication;
 
     private TaskExecutor(ExecutorService executorService, PostResult postResult) {
         mExecutorService = executorService;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Sameer Misger
