### PR TITLE
Making TaskExecutor volatile

### DIFF
--- a/library/src/main/java/net/vrallev/android/task/TaskExecutor.java
+++ b/library/src/main/java/net/vrallev/android/task/TaskExecutor.java
@@ -31,7 +31,7 @@ public final class TaskExecutor {
 
     private static final AtomicInteger TASK_COUNTER = new AtomicInteger(0);
 
-    private static TaskExecutor instance;
+    private static volatile TaskExecutor instance;
 
     public static TaskExecutor getInstance() {
         if (instance == null) {


### PR DESCRIPTION
Thanks for providing this awesome library.

A minor detail, as explained here: http://jeremymanson.blogspot.ch/2008/11/what-volatile-means-in-java.html one should use the volatile keyword when synchronizing a lazily constructed singleton. Otherwise the synchronization is not always warranted...
